### PR TITLE
Apply common structure to return value in relayMessages

### DIFF
--- a/dist/theglow.js
+++ b/dist/theglow.js
@@ -1608,7 +1608,7 @@ MailBox = (function(superClass) {
     return this.relayMessages(relay).then((function(_this) {
       return function(msgs) {
         msgs = msgs.filter(function(msg) {
-          return msg.uploadID === uploadID;
+          return msg.type == 'file' && msg.uploadID === uploadID;
         });
         return msgs[0];
       };

--- a/tests/specs/12a.files.coffee
+++ b/tests/specs/12a.files.coffee
@@ -56,13 +56,13 @@ describe 'File transfer, wrapper API', ->
   it 'start upload', ->
     r = new Relay(__globalTest.host)
 
-    metadata =
+    window.__globalTest.metadata =
       name: (randWord randNum 4,14) + '.zip'
       orig_size: FILE_SIZE
       created: randNum 1480000000, 1520000000
       modified: randNum 1480000000, 1520000000
 
-    Alice.startFileUpload('Bob', r, metadata).then (response) ->
+    Alice.startFileUpload('Bob', r, __globalTest.metadata).then (response) ->
       expect(response).to.contain.all.keys ['uploadID', 'max_chunk_size', 'storage_token', 'skey']
       expect(response.uploadID).to.be.a 'string'
       window.__globalTest.uploadID = response.uploadID
@@ -71,7 +71,7 @@ describe 'File transfer, wrapper API', ->
   for k in [0...NUMBER_OF_CHUNKS]
     it "uploading chunk #{k}", ->
       r = new Relay(__globalTest.host)
-      
+
       i = __globalTest.uploadChunkIterator++
       chunk = FILE_BINARY.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
 
@@ -87,6 +87,13 @@ describe 'File transfer, wrapper API', ->
         expect(responseBob.status).equal 'COMPLETE'
         # Bob downloads metadata, to get secret key required to decrypt file chunks
         Bob.getFileMetadata(r, __globalTest.uploadID).then (metadata) ->
+          expect(metadata.skey).to.be.a 'string'
+          expect(metadata.name).equal __globalTest.metadata.name
+          expect(metadata.orig_size).equal __globalTest.metadata.orig_size
+          expect(metadata.modified).equal __globalTest.metadata.modified
+          expect(metadata.created).equal __globalTest.metadata.created
+          expect(metadata.uploadID).equal __globalTest.uploadID
+
           window.__globalTest.metadata = metadata
 
   DECODED_FILE_BINARY = ''


### PR DESCRIPTION
Problem: When relayMessages process message with kind = 'file' structure of returned message differs from usual (missed fields 'fromTag', 'from', 'kind', 'time'). 
Solution adds required fields and move specific  'file message' data to  field msg.
Now each returned message will have same structure:
```json
{
"fromTag": "string",
"from": "string",
"kind": "type of message",
"nonce": "string",
"time": 12312312,
"msg": "{object specific to given 'kind'}"
}
```